### PR TITLE
Change GitHub share icon to text link

### DIFF
--- a/src/components/IssueDetail.tsx
+++ b/src/components/IssueDetail.tsx
@@ -62,24 +62,22 @@ export const IssueDetail: React.FC<IssueDetailProps> = ({ issue, repository }) =
             href={issue.html_url}
             target="_blank"
             rel="noopener noreferrer"
-            className="flex-shrink-0"
+            className="flex-shrink-0 text-sm text-muted-foreground hover:text-foreground flex items-center gap-1"
           >
-            <Button variant="ghost" size="sm">
-              <svg
-                className="w-4 h-4 mr-2"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
-                />
-              </svg>
-              GitHub
-            </Button>
+            <svg
+              className="w-3 h-3"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+              />
+            </svg>
+            GitHub
           </a>
         </div>
 


### PR DESCRIPTION
## Summary
- style the GitHub link on the issue details page as a small text label instead of a button

## Testing
- `npm test` *(fails: _openai.default.mockImplementation is not a function, SyntaxError: Unexpected token 'export')*

------
https://chatgpt.com/codex/tasks/task_e_6851d6129d948329801153f28f0e0ed5