### PR TITLE
Fix issue editor height

### DIFF
--- a/src/components/InlineEdit.tsx
+++ b/src/components/InlineEdit.tsx
@@ -130,7 +130,7 @@ export const InlineEdit: React.FC<InlineEditProps> = ({
         onKeyDown={handleKeyDown}
         className={cn(
           'w-full px-2 py-1 bg-background border rounded focus:outline-none focus:ring-2 focus:ring-primary',
-          multiline && 'resize-none min-h-[100px]',
+          multiline && 'resize-none min-h-screen',
           error && 'border-red-500',
           inputClassName
         )}


### PR DESCRIPTION
## Summary
- expand InlineEdit textarea so the issue body editor fills the viewport

## Testing
- `npm test` *(fails: _openai.default.mockImplementation is not a function; syntax errors from jose module)*

------
https://chatgpt.com/codex/tasks/task_b_68532b65a620832ba1c5a273e4fe3bbc